### PR TITLE
[sunjung] feat: 채팅 플로우 관리를 boot 메인 서버에 위임

### DIFF
--- a/src/main/java/com/ohgoodteam/ohgoodpay/config/CorsConfig.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/config/CorsConfig.java
@@ -1,0 +1,39 @@
+package com.ohgoodteam.ohgoodpay.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.Arrays;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(@org.springframework.lang.NonNull CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                // URL 끝에 슬래시(/)를 붙이면 CORS origin 매칭이 실패할 수 있으므로, 슬래시 없이 작성해야 합니다.
+                // Vite: http://localhost:5173, Live Server: http://localhost:5500
+                .allowedOrigins("http://localhost:5173", "http://127.0.0.1:5500")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .maxAge(3600);
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173", "http://127.0.0.1:5500"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/controller/ChatController.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/controller/ChatController.java
@@ -36,7 +36,7 @@ public class ChatController {
 //                    customerId,
                     request.getCustomerId(),
                     request.getSessionId(),
-                    request.getMessage(),
+                    request.getInputMessage(),
                     request.getFlow()
             );
             return ApiResponseWrapper.ok(response);

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/controller/ChatController.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/controller/ChatController.java
@@ -2,15 +2,8 @@ package com.ohgoodteam.ohgoodpay.recommend.controller;
 
 import com.ohgoodteam.ohgoodpay.recommend.dto.ChatStartRequestDTO;
 import com.ohgoodteam.ohgoodpay.recommend.dto.datadto.llmdto.BasicChatResponseDTO;
-import com.ohgoodteam.ohgoodpay.recommend.util.ApiErrorResponse;
 import com.ohgoodteam.ohgoodpay.recommend.service.ChatService;
 import com.ohgoodteam.ohgoodpay.recommend.util.ApiResponseWrapper;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/controller/ChatController.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/controller/ChatController.java
@@ -5,6 +5,7 @@ import com.ohgoodteam.ohgoodpay.recommend.dto.datadto.llmdto.BasicChatResponseDT
 import com.ohgoodteam.ohgoodpay.recommend.service.ChatService;
 import com.ohgoodteam.ohgoodpay.recommend.util.ApiResponseWrapper;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,10 +23,17 @@ public class ChatController {
 
     private final ChatService chatService;
 
-    @PostMapping("")
-    public ApiResponseWrapper<BasicChatResponseDTO> chat(@RequestBody ChatStartRequestDTO request) {
+    // TODO : 에러 정의를 좀 더 세분화 하는 방향 고려
+    @PostMapping()
+    public ApiResponseWrapper<BasicChatResponseDTO> chat(
+            @RequestBody ChatStartRequestDTO request,
+            HttpServletRequest httpRequest) {
         try {
+            // JWT에서 customerId 추출하는 파트 미리 만들어 놓음
+//            String customerId = jwtUtil.getCustomerIdFromToken(httpRequest);
+
             BasicChatResponseDTO response = chatService.chat(
+//                    customerId,
                     request.getCustomerId(),
                     request.getSessionId(),
                     request.getMessage(),

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/ChatFlowType.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/ChatFlowType.java
@@ -7,11 +7,12 @@ package com.ohgoodteam.ohgoodpay.recommend.dto;
  * 흐름 : 인사 & 기분 체크 > 취미 체크 > 뭐가 필요한지 체크 (추천 or 대시보드) > 다시 추천
  */
 public enum ChatFlowType {
-    MOODCHECK("mood_check"),
-    HOBBYCHECK("hobby_check"),
-    CHOOSE("choose"),
-    RECOMMENDATION("recommendation"),
-    RE_RECOMMENDATION("re-recommendation");
+    MOODCHECK("mood_check"), // 기분 체크하는 단계
+    HOBBYCHECK("hobby_check"), // 취미 체크하는 단계
+    CHOOSE("choose"), // 추천 or 대시보드 정의하는 단계
+    RECOMMENDATION("recommendation"), // 추천하는 단계
+    DASHBOARD("dashboard"), // 대시보드 보여주는 단계
+    RE_RECOMMENDATION("re-recommendation"); // 재추천하는 단계
 
     private final String value;
 

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/ChatFlowType.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/ChatFlowType.java
@@ -8,7 +8,7 @@ package com.ohgoodteam.ohgoodpay.recommend.dto;
  */
 public enum ChatFlowType {
     MOODCHECK("mood_check"),
-    HOBBYUPDATE("hobby_update"),
+    HOBBYCHECK("hobby_check"),
     CHOOSE("choose"),
     RECOMMENDATION("recommendation"),
     RE_RECOMMENDATION("re-recommendation");

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/ChatStartRequestDTO.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/ChatStartRequestDTO.java
@@ -16,5 +16,5 @@ public class ChatStartRequestDTO {
     private Long customerId;
     private String sessionId; // 프론트에서 관리하는 세션 ID
     private String inputMessage; // 사용자가 보낸 메시지
-//    private String flow; // 대화 흐름 (예: "recommendation", "general", etc.)
+    private String flow; // 대화 흐름 (예: "recommendation", "general", etc.)
 }

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/ChatStartRequestDTO.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/ChatStartRequestDTO.java
@@ -15,6 +15,6 @@ import lombok.*;
 public class ChatStartRequestDTO {
     private Long customerId;
     private String sessionId; // 프론트에서 관리하는 세션 ID
-    private String message; // 사용자가 보낸 메시지
-    private String flow; // 대화 흐름 (예: "recommendation", "general", etc.)
+    private String inputMessage; // 사용자가 보낸 메시지
+//    private String flow; // 대화 흐름 (예: "recommendation", "general", etc.)
 }

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/datadto/llmdto/BasicChatResponseDTO.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/datadto/llmdto/BasicChatResponseDTO.java
@@ -19,8 +19,6 @@ public class BasicChatResponseDTO{
     private String message;
 
     private String newHobby;       // 새로 파악한 취미
-    private boolean shouldUpdateHobbyDB; // DB 저장 신호
-
     private List<ProductDTO> products; // 추천 상품 목록
 
     // TODO : 성공하면 이거 정적 팩토리 메서드 생성하기

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/datadto/llmdto/ValidInputRequestDTO.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/datadto/llmdto/ValidInputRequestDTO.java
@@ -1,0 +1,18 @@
+package com.ohgoodteam.ohgoodpay.recommend.dto.datadto.llmdto;
+
+import lombok.*;
+
+/*
+* FAST API - 현재 사용자의 input이 유효한지 검증하는 DTO
+ */
+@Getter
+@ToString
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ValidInputRequestDTO {
+    private Long customerId;
+    private String sessionId; // 프론트에서 관리하는 세션 ID
+    private String inputMessage; // 사용자가 보낸 메시지
+    private String flow; // 메세지 비교를 위한 대화 흐름, 차후 REDIS에서 가져옴
+}

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/datadto/llmdto/ValidInputResponseDTO.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/datadto/llmdto/ValidInputResponseDTO.java
@@ -1,0 +1,20 @@
+package com.ohgoodteam.ohgoodpay.recommend.dto.datadto.llmdto;
+
+import lombok.*;
+
+/*
+ * FAST API - 현재 사용자의 input이 유효한지 검증 결과를 내보내는 DTO
+ */
+@Getter
+@ToString
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ValidInputResponseDTO {
+    private Long customerId;
+    private String sessionId;
+    private String inputMessage; // 사용자가 보낸 메시지, 한 번더 보낼때 재사용 하기 위함이다.
+    private boolean isValid; // 입력이 유효한지 여부
+    private String message; // LLM이 생성한 응답 메시지, 유효하지 않을 경우에만 사용할 예정.
+    private String flow; // 보냈던 대화 흐름 (다음 흐름으로 가도록 하기 위함이다. 이게 있어야 받아서 redis에 플로우 저장하고 다시 llm 요청 가능)
+}

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatCacheService.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatCacheService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
  * 고객 정보 캐싱 서비스 (REDIS)
  *
  * CacheStore Read-through 패턴 사용
+ * 세션별 관리와 고객별 관리 메서드를 분리하여 세션별로 초기화 해야 하는 정보와 고객별 정보를 명확히 구분
  */
 @Service
 @Slf4j
@@ -61,7 +62,7 @@ public class ChatCacheService {
     // 세션별 기분 조회
     public String getMoodBySession(String sessionId) {
         String mood = cacheStore.getBySession(CacheSpec.MOOD, sessionId, String.class);
-        return mood != null ? mood : "";
+        return mood != null ? mood : "쏘쏘";
     }
 
     // 세션별 대화 요약 조회

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatService.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatService.java
@@ -10,6 +10,4 @@ import com.ohgoodteam.ohgoodpay.recommend.dto.datadto.llmdto.BasicChatResponseDT
 public interface ChatService {
     // 채팅 생성
     BasicChatResponseDTO chat(Long customerId, String sessionId, String message, String flow);
-//    // 개인화 상품 추천
-//    ChatRecommendResponseDTO recommend(Long customerId);
 }

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatServiceImpl.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatServiceImpl.java
@@ -45,11 +45,10 @@ public class ChatServiceImpl implements ChatService {
         // 프론트에서 전달받은 sessionId 사용
         log.debug("Using sessionId: {} for customerId: {}", sessionId, customerId);
 
-
         CustomerCacheDTO customerInfo = chatCacheService.getCustomerInfo(customerId); //고객 기본 정보
         String hobby = chatCacheService.getHobby(customerId); //원래 저장되어 있었던 취미
         String mood = chatCacheService.getMoodBySession(sessionId); // 세션별 기분
-        Integer balance = chatCacheService.getBalance(customerId);
+        Integer balance = chatCacheService.getBalance(customerId); // 고객 잔액
         String summary = chatCacheService.getSummaryBySession(sessionId); // 세션별 대화 요약
 
         // LLM 서비스에 채팅 생성 요청 (검증된 enum 값 사용)

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatServiceImpl.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatServiceImpl.java
@@ -65,8 +65,8 @@ public class ChatServiceImpl implements ChatService {
                 flowType.getValue()
         );
 
-        // fast api에서 온 DB 저장 신호 확인
-        if (response.isShouldUpdateHobbyDB()) {
+        // fast api에서 newhobby가 왔을 경우,
+        if (!response.getNewHobby().equals("")) {
             // 신호가 왔다면, spring에서 DB에 저장
             customerRepository.updateHobbyByCustomerId(customerId, response.getNewHobby());
             log.info("취미 DB 업데이트 완료 - customerId: {}, hobby: {}",

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/FlowService.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/FlowService.java
@@ -1,0 +1,51 @@
+package com.ohgoodteam.ohgoodpay.recommend.service;
+
+import com.ohgoodteam.ohgoodpay.recommend.dto.ChatFlowType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+/**
+ * 채팅 플로우 관리 서비스
+ *
+ * 채팅 플로우의 전환 로직을 담당하며, validation 결과에 따라 다음 플로우 결정
+ * Redis 캐싱 없이 기본적인 플로우 관리 로직만 구현
+ */
+@Service
+@Slf4j
+public class FlowService {
+    /**
+     * 플로우 전환 맵 정의
+     * 현재 플로우 → 다음 플로우 매핑 (DASHBOARD 제외)
+     */
+    private static final Map<ChatFlowType, ChatFlowType> FLOW_TRANSITION = Map.of(
+            ChatFlowType.MOODCHECK, ChatFlowType.HOBBYCHECK,
+            ChatFlowType.HOBBYCHECK, ChatFlowType.CHOOSE,
+            ChatFlowType.CHOOSE, ChatFlowType.RECOMMENDATION,
+            ChatFlowType.RECOMMENDATION, ChatFlowType.RE_RECOMMENDATION,
+            ChatFlowType.RE_RECOMMENDATION, ChatFlowType.RE_RECOMMENDATION // 재추천은 계속 재추천
+    );
+
+    /**
+     * 다음 플로우 결정
+     * validation 성공 전제하에 다음 플로우 반환
+     *
+     * @param currentFlow 현재 플로우
+     * @return 다음 플로우
+     */
+    public String getNextFlow(String currentFlow) {
+        try {
+            ChatFlowType current = ChatFlowType.fromValue(currentFlow);
+            ChatFlowType next = FLOW_TRANSITION.get(current);
+
+            if (next != null) {
+                return next.getValue();
+            } else {
+                return currentFlow;
+            }
+        } catch (IllegalArgumentException e) {
+            return currentFlow;
+        }
+    }
+}

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ValidCheckService.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ValidCheckService.java
@@ -18,27 +18,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ValidCheckService {
     private final LlmService llmService;
-
-    /**
-     * 사용자 입력이 현재 플로우에 유효한지 검증
-     */
-    public boolean isValidInput(Long customerId, String sessionId, String inputMessage, String flow) {
-        ValidInputResponseDTO result = validateInput(customerId, sessionId, inputMessage, flow);
-        return result.isValid();
-    }
-
-    /**
-     * 검증 실패시 에러 메시지 반환
-     */
-    public String getValidationMessage(Long customerId, String sessionId, String inputMessage, String flow) {
-        ValidInputResponseDTO result = validateInput(customerId, sessionId, inputMessage, flow);
-        return result.getMessage();
-    }
-
     /**
      * LlmService를 통해 실제 검증 수행
      */
-    private ValidInputResponseDTO validateInput(Long customerId, String sessionId, String inputMessage, String flow) {
+    public ValidInputResponseDTO validateInput(Long customerId, String sessionId, String inputMessage, String flow) {
         ValidInputRequestDTO request = ValidInputRequestDTO.builder()
                 .customerId(customerId)
                 .sessionId(sessionId)

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ValidCheckService.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ValidCheckService.java
@@ -1,0 +1,51 @@
+package com.ohgoodteam.ohgoodpay.recommend.service;
+
+import com.ohgoodteam.ohgoodpay.recommend.dto.datadto.llmdto.ValidInputRequestDTO;
+import com.ohgoodteam.ohgoodpay.recommend.dto.datadto.llmdto.ValidInputResponseDTO;
+import com.ohgoodteam.ohgoodpay.recommend.service.fastapi.LlmService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 사용자 입력 검증 서비스
+ *
+ * ChatService의 validation 로직을 분리하여 책임을 명확히 함
+ * LlmService를 통해 FastAPI와 통신하여 입력 유효성 검증
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ValidCheckService {
+    private final LlmService llmService;
+
+    /**
+     * 사용자 입력이 현재 플로우에 유효한지 검증
+     */
+    public boolean isValidInput(Long customerId, String sessionId, String inputMessage, String flow) {
+        ValidInputResponseDTO result = validateInput(customerId, sessionId, inputMessage, flow);
+        return result.isValid();
+    }
+
+    /**
+     * 검증 실패시 에러 메시지 반환
+     */
+    public String getValidationMessage(Long customerId, String sessionId, String inputMessage, String flow) {
+        ValidInputResponseDTO result = validateInput(customerId, sessionId, inputMessage, flow);
+        return result.getMessage();
+    }
+
+    /**
+     * LlmService를 통해 실제 검증 수행
+     */
+    private ValidInputResponseDTO validateInput(Long customerId, String sessionId, String inputMessage, String flow) {
+        ValidInputRequestDTO request = ValidInputRequestDTO.builder()
+                .customerId(customerId)
+                .sessionId(sessionId)
+                .inputMessage(inputMessage)
+                .flow(flow)
+                .build();
+
+        return llmService.validateInput(request);
+    }
+}

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/fastapi/LlmService.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/fastapi/LlmService.java
@@ -20,4 +20,7 @@ public interface LlmService {
             String summary,
             String flow
     );
+
+    // 사용자 입력 검증
+    ValidInputResponseDTO validateInput(ValidInputRequestDTO request);
 }

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/fastapi/LlmServiceImpl.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/fastapi/LlmServiceImpl.java
@@ -42,4 +42,10 @@ public class LlmServiceImpl implements LlmService {
         );
         return fastApiClient.post("/chat", request, BasicChatResponseDTO.class);
     }
+
+    //TODO : FAST API 연동 필요
+    @Override
+    public ValidInputResponseDTO validateInput(ValidInputRequestDTO request) {
+        return fastApiClient.post("/validation", request, ValidInputResponseDTO.class);
+    }
 }

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/util/ApiErrorResponse.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/util/ApiErrorResponse.java
@@ -10,6 +10,8 @@ import java.time.LocalDateTime;
 
 /**
  * API 에러 응답 공통 DTO
+ *
+ * TODO : 공용으로 사용하지 않을시 삭제 예정....
  */
 @Getter
 @Builder

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/util/CacheSpec.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/util/CacheSpec.java
@@ -29,6 +29,8 @@ public enum CacheSpec {
     MOOD("v1:mood", Duration.ofMinutes(10)),
     // 5) 대화 요약본 - 1시간, 세션 초기화 시 초기화 하도록 구성
     SUMMARY("v1:summary", Duration.ofHours(1)); //메세지들 캐싱을 위해서 선언
+    // TODO : 플로우 관리 REDIS KEY 추가 (session 기반)
+    // TODO : CNT 로직 추가 (session 기반)
 
     private final String prefix; //키 네임 스페이스
     private final Duration ttl;

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/util/CacheSpec.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/util/CacheSpec.java
@@ -6,37 +6,29 @@ import lombok.RequiredArgsConstructor;
 import java.time.Duration;
 
 /**
- *  REDIS -> 전체 메세지 시간은 1H
- *  상품 같은 경우는 -> 디폴트 상품을 REDIS에 넣어둬도 될 것 같다.
- */
-
-/**
  * REDIS 캐싱을 위한 TTL 설정 값
+ * 세션별 관리는 앱세션 (화면 나갔다 들어오면 초기화)을 기준으로 한다.
  *
  * 캐시에 들어가야 할 값은 다음과 같다.
  * 1) 사용자 스냅샷(JSON) - {name, id, creditLimit}
  * 2) 잔액(int) - balance
  * 3) 취미(string) - hobby
- * [보류] 4) 최근 구매한 제품 카테고리(string) - recent_purchase
- * 5) 기분 (string) - mood
+ * 4) 기분 (string) - mood
+ * 5) 대화 요약본 (string) - summary
  */
 @Getter
 @RequiredArgsConstructor
 public enum CacheSpec {
-    // 1) 사용자 스냅샷(JSON)
+    // 1) 사용자 스냅샷(JSON), 12시간
     CUSTOMER("v1:customer", Duration.ofHours(12)),
     // 2) 잔액(String) - 3분
     BALANCE("v1:balance", Duration.ofMinutes(3)),
     // 3) 취미(List<String> or Set<String>) - 5분
     HOBBY("v1:hobby", Duration.ofMinutes(5)),
-//    // 4) 최근 구매한 제품 카테고리(List<String> or Set<String>) - 5분
-//    RECENT_PURCHASE("v1:recent_purchase", Duration.ofMinutes(5)),
-    // 5) 기분 데이터(String) - 10분
+    // 4) 기분 데이터(String) - 10분, 세션 초기화 시 초기화 하도록 구성
     MOOD("v1:mood", Duration.ofMinutes(10)),
-//    // 6) TOPN 추천 제품 캐싱 (List<RecommendProductDto>) - 10분
-//    RECOMMEND_PRODUCTS("v1:recommend_products", Duration.ofMinutes(10));
-
-    SUMMARY("v1:summary", Duration.ofHours(12)); //메세지들 캐싱을 위해서 선언
+    // 5) 대화 요약본 - 1시간, 세션 초기화 시 초기화 하도록 구성
+    SUMMARY("v1:summary", Duration.ofHours(1)); //메세지들 캐싱을 위해서 선언
 
     private final String prefix; //키 네임 스페이스
     private final Duration ttl;

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/util/FastApiClient.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/util/FastApiClient.java
@@ -22,6 +22,7 @@ public class FastApiClient {
         this.restTemplate = new RestTemplate();
     }
 
+    // post 메서드: 제네릭 타입 T 요청을 받아서 제네릭 타입 R 응답을 반환
     public <T, R> R post(String endpoint, T request, Class<R> responseType) {
         try {
             String url = fastApiBaseUrl + endpoint;

--- a/src/test/java/com/ohgoodteam/ohgoodpay/repository/CustomerRepositoryQueryTest.java
+++ b/src/test/java/com/ohgoodteam/ohgoodpay/repository/CustomerRepositoryQueryTest.java
@@ -28,16 +28,16 @@ public class CustomerRepositoryQueryTest {
             CustomerCacheDTO result = customerRepository.findCustomerCacheInfoById(testCustomerId);
             
             if (result != null) {
-                System.out.println("✅ findCustomerCacheInfoById 성공!");
+                System.out.println("findCustomerCacheInfoById 성공!");
                 System.out.println("Customer ID: " + result.getCustomerId());
                 System.out.println("Name: " + result.getName());
                 System.out.println("Credit Limit: " + result.getCreditLimit());
             } else {
-                System.out.println("⚠️ Customer ID " + testCustomerId + "가 존재하지 않습니다.");
+                System.out.println("Customer ID " + testCustomerId + "가 존재하지 않습니다.");
             }
             
         } catch (Exception e) {
-            System.err.println("❌ findCustomerCacheInfoById 실패: " + e.getMessage());
+            System.err.println("findCustomerCacheInfoById 실패: " + e.getMessage());
             e.printStackTrace();
             fail("findCustomerCacheInfoById 테스트 실패: " + e.getMessage());
         }
@@ -50,11 +50,11 @@ public class CustomerRepositoryQueryTest {
             
             Optional<String> hobby = customerRepository.findHobbyByCustomerId(testCustomerId);
             
-            System.out.println("✅ findHobbyByCustomerId 성공!");
+            System.out.println("findHobbyByCustomerId 성공!");
             System.out.println("Hobby: " + hobby.orElse("취미 없음"));
             
         } catch (Exception e) {
-            System.err.println("❌ findHobbyByCustomerId 실패: " + e.getMessage());
+            System.err.println("findHobbyByCustomerId 실패: " + e.getMessage());
             e.printStackTrace();
             fail("findHobbyByCustomerId 테스트 실패: " + e.getMessage());
         }
@@ -67,11 +67,11 @@ public class CustomerRepositoryQueryTest {
             
             Optional<Integer> balance = customerRepository.findBalanceByCustomerId(testCustomerId);
             
-            System.out.println("✅ findBalanceByCustomerId 성공!");
+            System.out.println("findBalanceByCustomerId 성공!");
             System.out.println("Balance: " + balance.orElse(0));
             
         } catch (Exception e) {
-            System.err.println("❌ findBalanceByCustomerId 실패: " + e.getMessage());
+            System.err.println("findBalanceByCustomerId 실패: " + e.getMessage());
             e.printStackTrace();
             fail("findBalanceByCustomerId 테스트 실패: " + e.getMessage());
         }
@@ -104,7 +104,7 @@ public class CustomerRepositoryQueryTest {
             }
             
         } catch (Exception e) {
-            System.err.println("❌ 전체 고객 쿼리 테스트 실패: " + e.getMessage());
+            System.err.println("전체 고객 쿼리 테스트 실패: " + e.getMessage());
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
## 📌 PR 종류

## 해당 되는 곳에 x 를 넣어주세요 [ ] -> [x]

- [x] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] refactor: 코드 리팩토링
- [ ] test: 테스트 코드 추가 또는 수정
- [ ] chore: 빌드 업무 수정, 패키지 매니저 수정 등

---

## ✨ 작업 내용

- 팀장님이 공유해주신 Cors 설정 파일 추가
- 챗 플로우 관리를 front가 아닌 boot 서버에 위임
- 플로우와 사용자 입력 메세지가 올바른지 llm이 검증하는 서비스 로직 추가

---

## ✅ 작업 상세 내용

- 플로우를 원래 front에서 request에 입력하는 간결한 방식을 사용했었는데,,,이렇게 할 경우 플로우 관리가 프론트에 종속되어 보안 문제 & 상태 관리 중앙화가 불가능한 문제가 있어서 이를 boot 서버에 위임하였습니다.
- 차후 redis로 상태 관리를 하여 서버를 stateless 하게 유지하되, 플로우 검증은 boot 서버에서 진행하는 방향으로 진행할 예정입니다. 현재는 플로우 관리 및 예외 처리 파트까지 틀만 구현완료
- 이를 통해 사용자가 채팅 플로우에 맞지 않는 값을 입력할시 견고한 제한이 가능합니다.

- 원래는 팀장님과 가은님 조언대로 프롬프터 튜닝을 통해 모든 예외처리와 플로우 관리를 Fast api에 위임할까 하는 생각도 했지만..(사실 일반 fast api로 개발하는 챗봇은 이 방식이 맞음!) 그렇게 하면 서버를 두 개로 분리한 이유가 없어지고 **(뭔가 그렇게 한다면 차라리 fast api 서버 하나만 쓰는게 더 낫다는 느낌..?)** 부트 서버가 사실상 메인 서버인데 너무 프록시 서버의 역할만 하는거 같아서....**일단 플로우 메인 관리를 boot에서 하고 & 프롬프터 튜닝을 보조 도구로 사용해서 좀 더 안전하고 견고한 방식으로 가고자합니다.** 
  - 보안이 빡센 금융권이나 규모가 큰 챗봇의 경우 실제로 이런식으로 서버를 분산해서 역할을 완전 분리 & redis로 관리 하는 방식으로 구현하고 있다고 하니, 저희가 페이 어플이니만큼 어느정도 명분은 있다고 생각합니다....
  - 솔직히 너무 오버엔지니어링 아닐까 하는 고민 정말정말 매우 많이 했는데, 이왕 서버 두 개 분리한거 & MVP 기간까지 시간 좀 있는김에 시도 해보고자 합니다....!! 여러 의미로 나쁠건 없을것 같아서리 

---

## 🔍 기타 참고사항

- 다음 단계로 Redis 통합 관리 진행할 예정...이제 fast api는 redis를 사용하지 않고 오직 추천과 llm 연동, 외부 api 연동의 역할만 가질 예정입니다.

---

## 📸 스크린샷

- X
