### PR TITLE
[sunjung] feat: 서버 플로우 1차 트러블 슈팅 & 리팩터링 완료

### DIFF
--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/controller/ChatController.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/controller/ChatController.java
@@ -36,8 +36,7 @@ public class ChatController {
 //                    customerId,
                     request.getCustomerId(),
                     request.getSessionId(),
-                    request.getInputMessage(),
-                    request.getFlow()
+                    request.getInputMessage()
             );
             return ApiResponseWrapper.ok(response);
 

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/ChatFlowType.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/ChatFlowType.java
@@ -11,7 +11,6 @@ public enum ChatFlowType {
     HOBBYCHECK("hobby_check"), // 취미 체크하는 단계
     CHOOSE("choose"), // 추천 or 대시보드 정의하는 단계
     RECOMMENDATION("recommendation"), // 추천하는 단계
-    DASHBOARD("dashboard"), // 대시보드 보여주는 단계
     RE_RECOMMENDATION("re-recommendation"); // 재추천하는 단계
 
     private final String value;

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/ChatFlowType.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/ChatFlowType.java
@@ -7,6 +7,7 @@ package com.ohgoodteam.ohgoodpay.recommend.dto;
  * 흐름 : 인사 & 기분 체크 > 취미 체크 > 뭐가 필요한지 체크 (추천 or 대시보드) > 다시 추천
  */
 public enum ChatFlowType {
+    START("start"),
     MOODCHECK("mood_check"), // 기분 체크하는 단계
     HOBBYCHECK("hobby_check"), // 취미 체크하는 단계
     CHOOSE("choose"), // 추천 or 대시보드 정의하는 단계

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/ChatStartRequestDTO.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/ChatStartRequestDTO.java
@@ -16,5 +16,4 @@ public class ChatStartRequestDTO {
     private Long customerId;
     private String sessionId; // 프론트에서 관리하는 세션 ID
     private String inputMessage; // 사용자가 보낸 메시지
-    private String flow; // 대화 흐름 (예: "recommendation", "general", etc.)
 }

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/CustomerContextWrapper.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/CustomerContextWrapper.java
@@ -1,0 +1,18 @@
+package com.ohgoodteam.ohgoodpay.recommend.dto;
+
+import com.ohgoodteam.ohgoodpay.recommend.dto.cache.CustomerCacheDTO;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 캐싱하는 정보를 전부 하나로 묶어서 service 로직에서 수집하기 위한 wrapper dto
+ */
+@Builder
+@Getter
+public class CustomerContextWrapper {
+    private final CustomerCacheDTO customerInfo;
+    private final String hobby;
+    private final String mood;
+    private final Integer balance;
+    private final String summary;
+}

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/ValidationResult.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/ValidationResult.java
@@ -1,0 +1,27 @@
+package com.ohgoodteam.ohgoodpay.recommend.dto;
+
+import com.ohgoodteam.ohgoodpay.recommend.dto.datadto.llmdto.BasicChatResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Validation 결과를 담는 DTO
+ */
+@AllArgsConstructor
+@Getter
+public class ValidationResult {
+    private final boolean shouldReturn;
+    private final BasicChatResponseDTO response;
+
+    public static ValidationResult continueFlow() {
+        return new ValidationResult(false, null);
+    }
+
+    public static ValidationResult returnResponse(BasicChatResponseDTO response) {
+        return new ValidationResult(true, response);
+    }
+
+    public boolean shouldReturn() {
+        return shouldReturn;
+    }
+}

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/datadto/llmdto/BasicChatResponseDTO.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/datadto/llmdto/BasicChatResponseDTO.java
@@ -20,6 +20,7 @@ public class BasicChatResponseDTO{
 
     private String newHobby;       // 새로 파악한 취미
     private List<ProductDTO> products; // 추천 상품 목록
+    private String summary;        // 대화 요약본
 
     // TODO : 성공하면 이거 정적 팩토리 메서드 생성하기
     // TODO : 시간 남으면 ChatStartResponseDTO 생성해서 응답용으로 감싸기

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/datadto/llmdto/ValidInputResponseDTO.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/dto/datadto/llmdto/ValidInputResponseDTO.java
@@ -1,5 +1,6 @@
 package com.ohgoodteam.ohgoodpay.recommend.dto.datadto.llmdto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 /*
@@ -14,6 +15,8 @@ public class ValidInputResponseDTO {
     private Long customerId;
     private String sessionId;
     private String inputMessage; // 사용자가 보낸 메시지, 한 번더 보낼때 재사용 하기 위함이다.
+
+    @JsonProperty("isValid") // fast api랑 json 직렬화를 맞추기 위함이다.
     private boolean isValid; // 입력이 유효한지 여부
     private String message; // LLM이 생성한 응답 메시지, 유효하지 않을 경우에만 사용할 예정.
     private String flow; // 보냈던 대화 흐름 (다음 흐름으로 가도록 하기 위함이다. 이게 있어야 받아서 redis에 플로우 저장하고 다시 llm 요청 가능)

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatCacheService.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatCacheService.java
@@ -91,4 +91,15 @@ public class ChatCacheService {
     public void saveFlowBySession(String sessionId, String flow) {
         cacheStore.saveBySession(CacheSpec.FLOW, sessionId, flow);
     }
+
+    // 세션별 플로우 count 조회
+    public Integer getCntBySession(String sessionId) {
+        Integer cnt = cacheStore.getBySession(CacheSpec.COUNT, sessionId, Integer.class);
+        return cnt != null ? cnt : 1; // count 없을 경우 기본이 1
+    }
+
+    // 세션별 플로우 count 저장
+    public void saveCntBySession(String sessionId, String flow) {
+        cacheStore.saveBySession(CacheSpec.COUNT, sessionId, flow);
+    }
 }

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatCacheService.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatCacheService.java
@@ -99,7 +99,7 @@ public class ChatCacheService {
     }
 
     // 세션별 플로우 count 저장
-    public void saveCntBySession(String sessionId, String flow) {
-        cacheStore.saveBySession(CacheSpec.COUNT, sessionId, flow);
+    public void saveCntBySession(String sessionId, Integer count) {
+        cacheStore.saveBySession(CacheSpec.COUNT, sessionId, count);
     }
 }

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatCacheService.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatCacheService.java
@@ -45,6 +45,12 @@ public class ChatCacheService {
         );
     }
 
+    // 고객 취미 정보 저장
+    public void saveHobby(Long customerId, String hobby) {
+        cacheStore.put(CacheSpec.HOBBY, customerId, hobby);
+        log.debug("취미를 customerId: {}로 저장 -> {}", customerId, hobby);
+    }
+
     // 고객 잔액 조회 (Read-through)
     // 잔액 정보가 없을 경우 50000원 기본값 반환 (일단은...)
     public Integer getBalance(Long customerId) {

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatCacheService.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatCacheService.java
@@ -90,7 +90,7 @@ public class ChatCacheService {
     // 세션별 플로우 조회
     public String getFlowBySession(String sessionId) {
         String flow = cacheStore.getBySession(CacheSpec.FLOW, sessionId, String.class);
-        return flow != null ? flow : "mood_check"; // 플로우 없을 경우 기본값: 첫 번째 플로우
+        return flow != null ? flow : "start"; // 플로우 없을 경우 기본값: 첫 번째 플로우
     }
 
     // 세션별 플로우 저장

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatCacheService.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatCacheService.java
@@ -65,9 +65,30 @@ public class ChatCacheService {
         return mood != null ? mood : "쏘쏘";
     }
 
+    // 세션별 기분 저장
+    public void saveMoodBySession(String sessionId, String mood) {
+        cacheStore.saveBySession(CacheSpec.MOOD, sessionId, mood);
+    }
+
     // 세션별 대화 요약 조회
     public String getSummaryBySession(String sessionId) {
         String summary = cacheStore.getBySession(CacheSpec.SUMMARY, sessionId, String.class);
         return summary != null ? summary : ""; // 기본값
+    }
+
+    // 세션별 대화 요약 저장
+    public void saveSummaryBySession(String sessionId, String summary) {
+        cacheStore.saveBySession(CacheSpec.SUMMARY, sessionId, summary);
+    }
+
+    // 세션별 플로우 조회
+    public String getFlowBySession(String sessionId) {
+        String flow = cacheStore.getBySession(CacheSpec.FLOW, sessionId, String.class);
+        return flow != null ? flow : "mood_check"; // 플로우 없을 경우 기본값: 첫 번째 플로우
+    }
+
+    // 세션별 플로우 저장
+    public void saveFlowBySession(String sessionId, String flow) {
+        cacheStore.saveBySession(CacheSpec.FLOW, sessionId, flow);
     }
 }

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatService.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatService.java
@@ -9,5 +9,5 @@ import com.ohgoodteam.ohgoodpay.recommend.dto.datadto.llmdto.BasicChatResponseDT
  */
 public interface ChatService {
     // 채팅 생성
-    BasicChatResponseDTO chat(Long customerId, String sessionId, String message, String flow);
+    BasicChatResponseDTO chat(Long customerId, String sessionId, String message);
 }

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatServiceImpl.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatServiceImpl.java
@@ -33,7 +33,7 @@ public class ChatServiceImpl implements ChatService {
     @Override
     @Transactional(readOnly = true)
     public BasicChatResponseDTO chat(Long customerId, String sessionId, String message) {
-        log.debug("세션 아이디와 고객 아이디 체크 sessionId: {} for customerId: {}", sessionId, customerId);
+        log.info("세션 아이디와 고객 아이디 체크 sessionId: {} for customerId: {}", sessionId, customerId);
 
         // 0. flow를 redis에서 가져오기
         String currentFlow = chatCacheService.getFlowBySession(sessionId);
@@ -45,23 +45,24 @@ public class ChatServiceImpl implements ChatService {
             return validationResult.getResponse();
         }
 
-        // 2. 플로우 전환 및 전처리
-        String nextFlow;
-        if (!validated.isValid() && chatCacheService.getCntBySession(sessionId) == 2) {
-            // cnt == 2인 경우, processValidationResult에서 이미 플로우 변경됨
-            nextFlow = chatCacheService.getFlowBySession(sessionId);
-        } else {
-            // 정상적인 플로우 전환
-            nextFlow = flowService.getNextFlow(currentFlow);
+        // 2. 플로우 전환 및 전처리, 동일한 플로우를 위해 위에 추가함.
+        String nextFlow = flowService.getNextFlow(currentFlow);
+        // 카운트 리셋만 하고 invalid 데이터는 저장하지 않음
+        chatCacheService.saveCntBySession(sessionId, 1); //count 초기화
+        chatCacheService.saveFlowBySession(sessionId, nextFlow); //nextflow 초기화
+        log.info("캐싱되어 있는 바뀐 플로우 확인하기 : {}", chatCacheService.getFlowBySession(sessionId));
+
+        if (validated.isValid()) {
             saveFlowSpecificData(customerId, sessionId, nextFlow, validated);
         }
         // 3. 캐싱된 데이터 수집
         CustomerContextWrapper context = collectCachedData(customerId, sessionId);
         // 4. LLM 요청
         BasicChatResponseDTO response = requestToLLM(sessionId, context, message, nextFlow);
-        // 5. 응답 후처리
-        processAfterResponse(response, customerId, sessionId, nextFlow);
-
+        // 5. 응답 후처리, 강제로 넘어간 경우는 저장 무시한다.
+        if (validated.isValid()) {
+            processAfterResponse(response, customerId, sessionId, nextFlow);
+        }
         return response;
     }
 
@@ -70,6 +71,7 @@ public class ChatServiceImpl implements ChatService {
      */
     private ValidationResult processValidationResult(ValidInputResponseDTO validated, Long customerId, String sessionId, String currentFlow) {
         if (!validated.isValid()) {
+            log.info("----------isValid = false라고 잘못오는 거임! : {}----------", validated.isValid());
             int cnt = chatCacheService.getCntBySession(sessionId);
             // 두 번 이하로 유효하지 않은 응답이 들어왔을경우, 다시 같은 플로우를 실행
             if (cnt < 2) {
@@ -84,13 +86,10 @@ public class ChatServiceImpl implements ChatService {
             } else if(cnt == 2){
                 // cnt == 2면 다음 플로우로 강제 진행하고 LLM 요청 계속 진행
                 log.info("Validation 실패 {}번, 다음 플로우로 넘어가서 LLM 요청 진행", cnt);
-                String nextFlow = flowService.getNextFlow(currentFlow);
-                // 카운트 리셋만 하고 invalid 데이터는 저장하지 않음
-                chatCacheService.saveCntBySession(sessionId, 1);
-                chatCacheService.saveFlowBySession(sessionId, nextFlow);
                 return ValidationResult.continueFlow();
             }
         }
+        log.info("------------isValid True로 인해 플로우를 그대로 이어나간다.----------");
         return ValidationResult.continueFlow();
     }
 
@@ -114,11 +113,11 @@ public class ChatServiceImpl implements ChatService {
         // 플로우 전환시 카운트 리셋
         chatCacheService.saveCntBySession(sessionId, 1);
         // 특정 플로우에서 mood 저장, 유효한 경우엔 캐싱하고 아닌 경우엔 저장 없이 플로우만 넘기도록 한다.
-        if (!validated.isValid() && "hobby_check".equals(nextFlow) && validated != null) {
+        if ("hobby_check".equals(nextFlow) && validated != null) {
             chatCacheService.saveMoodBySession(sessionId, validated.getInputMessage());
         }
         // 특정 플로우에서 hobby 저장
-        if (!validated.isValid() && "choose".equals(nextFlow) && validated != null) {
+        if ("choose".equals(nextFlow) && validated != null) {
             chatCacheService.saveHobby(customerId, validated.getInputMessage());
         }
     }
@@ -153,7 +152,5 @@ public class ChatServiceImpl implements ChatService {
         if (response.getSummary() != null && !response.getSummary().isEmpty()) {
             chatCacheService.saveSummaryBySession(sessionId, response.getSummary());
         }
-        // 새로 바뀐 플로우 저장
-        chatCacheService.saveFlowBySession(sessionId, nextFlow);
     }
 }

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatServiceImpl.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatServiceImpl.java
@@ -71,7 +71,6 @@ public class ChatServiceImpl implements ChatService {
      */
     private ValidationResult processValidationResult(ValidInputResponseDTO validated, Long customerId, String sessionId, String currentFlow) {
         if (!validated.isValid()) {
-            log.info("----------isValid = false라고 잘못오는 거임! : {}----------", validated.isValid());
             int cnt = chatCacheService.getCntBySession(sessionId);
             // 두 번 이하로 유효하지 않은 응답이 들어왔을경우, 다시 같은 플로우를 실행
             if (cnt < 2) {
@@ -83,7 +82,7 @@ public class ChatServiceImpl implements ChatService {
                         .products(null)
                         .build();
                 return ValidationResult.returnResponse(errorResponse);
-            } else if(cnt == 2){
+            } else if(cnt == 2) {
                 // cnt == 2면 다음 플로우로 강제 진행하고 LLM 요청 계속 진행
                 log.info("Validation 실패 {}번, 다음 플로우로 넘어가서 LLM 요청 진행", cnt);
                 return ValidationResult.continueFlow();
@@ -111,6 +110,7 @@ public class ChatServiceImpl implements ChatService {
      */
     private void saveFlowSpecificData(Long customerId, String sessionId, String nextFlow, ValidInputResponseDTO validated) {
         // 플로우 전환시 카운트 리셋
+        // TODO : 이거 0으로 만들고 세는 방향으로 가야할 것 같아서 고민중
         chatCacheService.saveCntBySession(sessionId, 1);
         // 특정 플로우에서 mood 저장, 유효한 경우엔 캐싱하고 아닌 경우엔 저장 없이 플로우만 넘기도록 한다.
         if ("hobby_check".equals(nextFlow) && validated != null) {

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatServiceImpl.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatServiceImpl.java
@@ -40,13 +40,21 @@ public class ChatServiceImpl implements ChatService {
 
         // 1. Validation 및 재시도 체크
         ValidInputResponseDTO validated = validCheckService.validateInput(customerId, sessionId, message, currentFlow);
-        ValidationResult validationResult = processValidationResult(validated, customerId, sessionId);
+        ValidationResult validationResult = processValidationResult(validated, customerId, sessionId, currentFlow);
         if (validationResult.shouldReturn()) { //바로 리턴 해야 한다면, 플로우 변환 없이 처리
             return validationResult.getResponse();
         }
+
         // 2. 플로우 전환 및 전처리
-        String nextFlow = flowService.getNextFlow(currentFlow);
-        saveFlowSpecificData(customerId, sessionId, nextFlow, validated);
+        String nextFlow;
+        if (!validated.isValid() && chatCacheService.getCntBySession(sessionId) == 2) {
+            // cnt == 2인 경우, processValidationResult에서 이미 플로우 변경됨
+            nextFlow = chatCacheService.getFlowBySession(sessionId);
+        } else {
+            // 정상적인 플로우 전환
+            nextFlow = flowService.getNextFlow(currentFlow);
+            saveFlowSpecificData(customerId, sessionId, nextFlow, validated);
+        }
         // 3. 캐싱된 데이터 수집
         CustomerContextWrapper context = collectCachedData(customerId, sessionId);
         // 4. LLM 요청
@@ -60,7 +68,7 @@ public class ChatServiceImpl implements ChatService {
     /**
      * 검증 결과 처리 및 재시도 로직
      */
-    private ValidationResult processValidationResult(ValidInputResponseDTO validated, Long customerId, String sessionId) {
+    private ValidationResult processValidationResult(ValidInputResponseDTO validated, Long customerId, String sessionId, String currentFlow) {
         if (!validated.isValid()) {
             int cnt = chatCacheService.getCntBySession(sessionId);
             // 두 번 이하로 유효하지 않은 응답이 들어왔을경우, 다시 같은 플로우를 실행
@@ -73,9 +81,15 @@ public class ChatServiceImpl implements ChatService {
                         .products(null)
                         .build();
                 return ValidationResult.returnResponse(errorResponse);
+            } else if(cnt == 2){
+                // cnt == 2면 다음 플로우로 강제 진행하고 LLM 요청 계속 진행
+                log.info("Validation 실패 {}번, 다음 플로우로 넘어가서 LLM 요청 진행", cnt);
+                String nextFlow = flowService.getNextFlow(currentFlow);
+                // 카운트 리셋만 하고 invalid 데이터는 저장하지 않음
+                chatCacheService.saveCntBySession(sessionId, 1);
+                chatCacheService.saveFlowBySession(sessionId, nextFlow);
+                return ValidationResult.continueFlow();
             }
-            // cnt >= 2면 다음 플로우로 강제 진행
-            log.info("Validation 실패 {}번, 다음 플로우로 바로 넘어간다.", cnt);
         }
         return ValidationResult.continueFlow();
     }
@@ -99,12 +113,12 @@ public class ChatServiceImpl implements ChatService {
     private void saveFlowSpecificData(Long customerId, String sessionId, String nextFlow, ValidInputResponseDTO validated) {
         // 플로우 전환시 카운트 리셋
         chatCacheService.saveCntBySession(sessionId, 1);
-        // 특정 플로우에서 mood 저장
-        if ("hobby_check".equals(nextFlow) && validated != null) {
+        // 특정 플로우에서 mood 저장, 유효한 경우엔 캐싱하고 아닌 경우엔 저장 없이 플로우만 넘기도록 한다.
+        if (!validated.isValid() && "hobby_check".equals(nextFlow) && validated != null) {
             chatCacheService.saveMoodBySession(sessionId, validated.getInputMessage());
         }
         // 특정 플로우에서 hobby 저장
-        if ("choose".equals(nextFlow) && validated != null) {
+        if (!validated.isValid() && "choose".equals(nextFlow) && validated != null) {
             chatCacheService.saveHobby(customerId, validated.getInputMessage());
         }
     }

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatServiceImpl.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/ChatServiceImpl.java
@@ -1,8 +1,8 @@
 package com.ohgoodteam.ohgoodpay.recommend.service;
 
 import com.ohgoodteam.ohgoodpay.common.repository.CustomerRepository;
-import com.ohgoodteam.ohgoodpay.recommend.dto.ChatFlowType;
-import com.ohgoodteam.ohgoodpay.recommend.dto.cache.CustomerCacheDTO;
+import com.ohgoodteam.ohgoodpay.recommend.dto.CustomerContextWrapper;
+import com.ohgoodteam.ohgoodpay.recommend.dto.ValidationResult;
 import com.ohgoodteam.ohgoodpay.recommend.dto.datadto.llmdto.*;
 import com.ohgoodteam.ohgoodpay.recommend.service.fastapi.LlmService;
 import lombok.RequiredArgsConstructor;
@@ -33,81 +33,110 @@ public class ChatServiceImpl implements ChatService {
     @Override
     @Transactional(readOnly = true)
     public BasicChatResponseDTO chat(Long customerId, String sessionId, String message, String flow) {
-        log.debug("Using sessionId: {} for customerId: {}", sessionId, customerId);
+        log.debug("세션 아이디와 고객 아이디 체크 sessionId: {} for customerId: {}", sessionId, customerId);
 
-        // 입력 검증
+        // 1. Validation 및 재시도 체크
         ValidInputResponseDTO validated = validCheckService.validateInput(customerId, sessionId, message, flow);
+        ValidationResult validationResult = processValidationResult(validated, customerId, sessionId);
+        if (validationResult.shouldReturn()) { //바로 리턴 해야 한다면, 플로우 변환 없이 처리
+            return validationResult.getResponse();
+        }
+        // 2. 플로우 전환 및 전처리
+        String nextFlow = flowService.getNextFlow(flow);
+        saveFlowSpecificData(customerId, sessionId, nextFlow, validated);
+        // 3. 캐싱된 데이터 수집
+        CustomerContextWrapper context = collectCachedData(customerId, sessionId);
+        // 4. LLM 요청
+        BasicChatResponseDTO response = requestToLLM(sessionId, context, message, nextFlow);
+        // 5. 응답 후처리
+        processAfterResponse(response, customerId, sessionId, nextFlow);
 
-        // 입력이 유효하지 않으면 현재 플로우 유지하고 에러 메시지를 바로 응답.
+        return response;
+    }
+
+    /**
+     * 검증 결과 처리 및 재시도 로직
+     */
+    private ValidationResult processValidationResult(ValidInputResponseDTO validated, Long customerId, String sessionId) {
         if (!validated.isValid()) {
             int cnt = chatCacheService.getCntBySession(sessionId);
-            if(cnt < 2){
-                chatCacheService.saveCntBySession(sessionId, cnt + 1); // 카운트 증가 후 저장
-                return BasicChatResponseDTO.builder()
+            // 두 번 이하로 유효하지 않은 응답이 들어왔을경우, 다시 같은 플로우를 실행
+            if (cnt < 2) {
+                chatCacheService.saveCntBySession(sessionId, cnt + 1);
+                BasicChatResponseDTO errorResponse = BasicChatResponseDTO.builder()
                         .sessionId(sessionId)
                         .message(validated.getMessage())
                         .newHobby("")
                         .products(null)
                         .build();
+                return ValidationResult.returnResponse(errorResponse);
             }
             // cnt >= 2면 다음 플로우로 강제 진행
             log.info("Validation 실패 {}번, 다음 플로우로 바로 넘어간다.", cnt);
         }
+        return ValidationResult.continueFlow();
+    }
 
-        // validation 성공 또는 2번 실패 후 다음 플로우로 전환
-        String nextFlow = flowService.getNextFlow(flow);
+    /**
+     * 캐싱된 데이터 수집
+     */
+    private CustomerContextWrapper collectCachedData(Long customerId, String sessionId) {
+        return CustomerContextWrapper.builder()
+                .customerInfo(chatCacheService.getCustomerInfo(customerId))
+                .hobby(chatCacheService.getHobby(customerId))
+                .mood(chatCacheService.getMoodBySession(sessionId))
+                .balance(chatCacheService.getBalance(customerId))
+                .summary(chatCacheService.getSummaryBySession(sessionId))
+                .build();
+    }
 
-        //====== LLM 전송 전에 캐싱 필요한 파트들 ==========
+    /**
+     * 플로우별 특정 데이터 저장
+     */
+    private void saveFlowSpecificData(Long customerId, String sessionId, String nextFlow, ValidInputResponseDTO validated) {
         // 플로우 전환시 카운트 리셋
         chatCacheService.saveCntBySession(sessionId, 1);
-
         // 특정 플로우에서 mood 저장
         if ("hobby_check".equals(nextFlow) && validated != null) {
             chatCacheService.saveMoodBySession(sessionId, validated.getInputMessage());
         }
-
         // 특정 플로우에서 hobby 저장
         if ("choose".equals(nextFlow) && validated != null) {
             chatCacheService.saveHobby(customerId, validated.getInputMessage());
         }
+    }
 
-        // 입력이 유효한 경우 기존 채팅 생성 로직 수행
-        CustomerCacheDTO customerInfo = chatCacheService.getCustomerInfo(customerId);
-        String hobby = chatCacheService.getHobby(customerId);
-        String mood = chatCacheService.getMoodBySession(sessionId);
-        Integer balance = chatCacheService.getBalance(customerId);
-        String summary = chatCacheService.getSummaryBySession(sessionId);
-
-        // LLM 서비스에 채팅 생성 요청 (다음 플로우로)
-        // TODO : 차후 nextFlow 부분 FRONT에서 제거하고 REDIS로 이관 예정
-        BasicChatResponseDTO response = llmService.generateChat(
+    /**
+     * LLM 요청 처리
+     */
+    private BasicChatResponseDTO requestToLLM(String sessionId, CustomerContextWrapper context, String message, String nextFlow) {
+        return llmService.generateChat(
                 sessionId,
-                customerInfo,
-                mood,
-                hobby,
-                balance,
+                context.getCustomerInfo(),
+                context.getMood(),
+                context.getHobby(),
+                context.getBalance(),
                 message,
-                summary,
+                context.getSummary(),
                 nextFlow
         );
+    }
 
-        // fast api에서 newhobby가 왔을 경우 DB 업데이트
-        // TODO : 향후 로직 리팩터링시 분리 예정...
+    /**
+     * 응답 후처리 (DB 업데이트, 캐싱)
+     */
+    private void processAfterResponse(BasicChatResponseDTO response, Long customerId, String sessionId, String nextFlow) {
+        // DB 업데이트
         if (!response.getNewHobby().equals("")) {
             customerRepository.updateHobbyByCustomerId(customerId, response.getNewHobby());
             log.info("취미 DB 업데이트 완료 - customerId: {}, hobby: {}", customerId, response.getNewHobby());
         }
-
-        //====== LLM 전송 후에 캐싱 필요한 파트들 ==========
-
-        // 대화 요약본 저장 (LLM이 업데이트된 요약본 제공)
+        // 캐싱
+        // 요약본 저장
         if (response.getSummary() != null && !response.getSummary().isEmpty()) {
             chatCacheService.saveSummaryBySession(sessionId, response.getSummary());
         }
-        // 세션에 flow 새로 저장
+        // 새로 바뀐 플로우 저장
         chatCacheService.saveFlowBySession(sessionId, nextFlow);
-
-        return response;
     }
-
 }

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/FlowService.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/FlowService.java
@@ -20,6 +20,7 @@ public class FlowService {
      * 현재 플로우 → 다음 플로우 매핑 (DASHBOARD 제외)
      */
     private static final Map<ChatFlowType, ChatFlowType> FLOW_TRANSITION = Map.of(
+            ChatFlowType.START, ChatFlowType.MOODCHECK,
             ChatFlowType.MOODCHECK, ChatFlowType.HOBBYCHECK,
             ChatFlowType.HOBBYCHECK, ChatFlowType.CHOOSE,
             ChatFlowType.CHOOSE, ChatFlowType.RECOMMENDATION,

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/fastapi/LlmServiceImpl.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/service/fastapi/LlmServiceImpl.java
@@ -46,6 +46,6 @@ public class LlmServiceImpl implements LlmService {
     //TODO : FAST API 연동 필요
     @Override
     public ValidInputResponseDTO validateInput(ValidInputRequestDTO request) {
-        return fastApiClient.post("/validation", request, ValidInputResponseDTO.class);
+        return fastApiClient.post("/chat/validation", request, ValidInputResponseDTO.class);
     }
 }

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/util/CacheSpec.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/util/CacheSpec.java
@@ -28,9 +28,11 @@ public enum CacheSpec {
     // 4) 기분 데이터(String) - 10분, 세션 초기화 시 초기화 하도록 구성
     MOOD("v1:mood", Duration.ofMinutes(10)),
     // 5) 대화 요약본 - 1시간, 세션 초기화 시 초기화 하도록 구성
-    SUMMARY("v1:summary", Duration.ofHours(1)); //메세지들 캐싱을 위해서 선언
-    // TODO : 플로우 관리 REDIS KEY 추가 (session 기반)
-    // TODO : CNT 로직 추가 (session 기반)
+    SUMMARY("v1:summary", Duration.ofHours(1)), //메세지들 캐싱을 위해서 선언
+    // 6) 플로우 - 1시간, 세션 초기화 시 초기화 하도록 구성
+    FLOW("v1:flow", Duration.ofHours(1)), //플로우 캐싱을 위해 선언
+    // 7) 카운트 - 1시간, 세션 초기화 시 초기화 하도록 구성
+    COUNT("v1:count", Duration.ofHours(1)); //플로우 카운트를 위해 선언
 
     private final String prefix; //키 네임 스페이스
     private final Duration ttl;

--- a/src/main/java/com/ohgoodteam/ohgoodpay/recommend/util/CacheStore.java
+++ b/src/main/java/com/ohgoodteam/ohgoodpay/recommend/util/CacheStore.java
@@ -101,6 +101,15 @@ public class CacheStore {
         }
     }
 
+    // saveBySession 메서드 (putBySession과 동일, 네이밍 일관성을 위해 추가)
+    public void saveBySession(CacheSpec spec, String sessionId, Object value) {
+        putBySession(spec, sessionId, value);
+    }
+
+    public void saveBySession(CacheSpec spec, String sessionId, Object value, Duration ttl) {
+        putBySession(spec, sessionId, value, ttl);
+    }
+
     // Read-through 패턴 구현
     public <T> T getOrLoad(CacheSpec spec, Object userId, Class<T> type, Supplier<T> loader) {
         T cached = this.get(spec, userId, type);


### PR DESCRIPTION
## 📌 PR 종류

## 해당 되는 곳에 x 를 넣어주세요 [ ] -> [x]

- [x] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [x] refactor: 코드 리팩토링
- [ ] test: 테스트 코드 추가 또는 수정
- [ ] chore: 빌드 업무 수정, 패키지 매니저 수정 등

---

## ✨ 작업 내용

- 플로우 관련 1차 트러블 슈팅 완료
- 이상한 응답?에 대해 한 번 기회 주도록 하는 로직 구현 완료

---

## ✅ 작업 상세 내용

- 플로우 서버가 전부 관리하도록 위임한 이후, 트러블 슈팅하면서 플로우 이상한 부분 해결했습니다.
- start 진입점이 필요해서 진입점 관련 상태 추가하고, 그외 여러 자잘한 문제들 다 수정했습니다.
- 기분 캐싱 안 되던 문제, valid/chat 분리했는데 유효성 검증을 두군데서 중복해서 하던 문제, 그외 start 점에서는 유효성 검증 스킵하고 진행하는 것까지 (어차피 입력이 없으니까 검증할 것도 없슴당) 다 해결 완료했습니다.

---

## 🔍 기타 참고사항

- 지금 정리 못해서 문서가 엉망이긴한데, 트러블 슈팅 하면서 정리한거 일단 공유합니다. 차후 문저 깔끔하게 다듬을 예정..
https://humdrum-lobster-dc7.notion.site/1-2705ce675819805db2fec20e7ec2bc81?source=copy_link

- 아직 상품 재추천단은 구현 덜 되어 있는 상태이고, 대시보드의 경우는 그냥 리액트에서 컴포넌트 불러오는 방식으로 클라이언트 사이드로 처리하려고 합니다.

---

## 📸 스크린샷

<img width="934" height="284" alt="image" src="https://github.com/user-attachments/assets/303a888c-efba-4176-b0ff-6d5fb57da34d" />
<img width="910" height="188" alt="image" src="https://github.com/user-attachments/assets/6033c6da-6660-46d6-b61a-a990c4e98d36" />

플로우 관리를 전부 서버 & redis 캐싱으로 위임해서 프론트 request에 flow가 없습니다. 이를 통해 프론트는 플로우를 모르고 정보만 전달해도 플로우에 맞는 화면을 띄울 수 있습니다. 프론트에 종속 로직을 최소화 하는게 좋기에..이렇게 구성